### PR TITLE
fix names in fill_matrix makefile

### DIFF
--- a/hands-on/gpu/cuda/03_fill_the_matrix/Makefile
+++ b/hands-on/gpu/cuda/03_fill_the_matrix/Makefile
@@ -1,3 +1,3 @@
 
 all:
-	nvcc fill_the_matrix.cu -o fill_the_matrix.out
+	nvcc matrix.cu -o matrix.out


### PR DESCRIPTION
The file is called `matrix.cu` but Makefile tries to build `fill_the_matrix.cu`